### PR TITLE
Unknown off fix

### DIFF
--- a/src/samus.c
+++ b/src/samus.c
@@ -7946,6 +7946,7 @@ void SamusInit(void)
 
             // Starting events
             EventFunction(EVENT_ACTION_SETTING, EVENT_FULLY_POWERED_SUIT_OBTAINED);  // For less stupid Chozodia access
+			EventFunction(EVENT_ACTION_CLEARING, EVENT_RUINS_TEST_PASSED);  // Hopefully fixes unknowns off
             for (i = EVENT_ENTER_NORFAIR_DEMO_PLAYED; i <= EVENT_STATUE_SCREW_ATTACK_GRABBED; i++)
                 EventFunction(EVENT_ACTION_SETTING, i);
             EventFunction(EVENT_ACTION_CLEARING, EVENT_ENTER_RIDLEY_DEMO_PLAYED);

--- a/src/samus.c
+++ b/src/samus.c
@@ -7946,7 +7946,7 @@ void SamusInit(void)
 
             // Starting events
             EventFunction(EVENT_ACTION_SETTING, EVENT_FULLY_POWERED_SUIT_OBTAINED);  // For less stupid Chozodia access
-			EventFunction(EVENT_ACTION_CLEARING, EVENT_RUINS_TEST_PASSED);  // Hopefully fixes unknowns off
+            EventFunction(EVENT_ACTION_CLEARING, EVENT_RUINS_TEST_PASSED);  // Hopefully fixes unknowns off
             for (i = EVENT_ENTER_NORFAIR_DEMO_PLAYED; i <= EVENT_STATUE_SCREW_ATTACK_GRABBED; i++)
                 EventFunction(EVENT_ACTION_SETTING, i);
             EventFunction(EVENT_ACTION_CLEARING, EVENT_ENTER_RIDLEY_DEMO_PLAYED);


### PR DESCRIPTION
This clears the RUINS_TEST_PASSED event on save file initialization which hopefully fixes the issues with the unknown items being weird. I tested a solo seed and my unknowns were correctly handled both when collected locally and sent from the server via !getitem, and they all correctly came online upon passing the Ruins Test for real.